### PR TITLE
fix(popover): 修复默认占位按钮的类型

### DIFF
--- a/libraries/mobile-ui/src-vusion/components/popup-combination/demos/blocks/BlocksDemo1.vue
+++ b/libraries/mobile-ui/src-vusion/components/popup-combination/demos/blocks/BlocksDemo1.vue
@@ -3,7 +3,7 @@
 <template>
   <van-popup-combination>
   <template #reference>
-    <van-button type="primary" text="触发弹出框组件，可删除替换"></van-button>
+    <van-button type="info" text="触发弹出框组件，可删除替换"></van-button>
   </template>
   <van-text text="内容"></van-text>
 </van-popup-combination>


### PR DESCRIPTION
当前类型不在类型列表中，显示为英文