### PR TITLE
fix: 修复幻灯片默认block图片属性配置

### DIFF
--- a/libraries/mobile-ui/src/swipe/demos/blocks/BlocksDemo1.vue
+++ b/libraries/mobile-ui/src/swipe/demos/blocks/BlocksDemo1.vue
@@ -2,10 +2,18 @@
 
 <template>
 <van-swipe class="my-swipe" :autoplay="3000" indicatorColor="white" style="height:200px;">
-  <van-swipe-item vusion-slot-name="default"><van-image style="width:100%;height:100%" src="https://static-vusion.163yun.com/assets/cloud-ui/1.jpg"></van-image></van-swipe-item>
-  <van-swipe-item vusion-slot-name="default"><van-image style="width:100%;height:100%" src="https://static-vusion.163yun.com/assets/cloud-ui/2.jpg"></van-image></van-swipe-item>
-  <van-swipe-item vusion-slot-name="default"><van-image style="width:100%;height:100%" src="https://static-vusion.163yun.com/assets/cloud-ui/3.jpg"></van-image></van-swipe-item>
-  <van-swipe-item vusion-slot-name="default"><van-image style="width:100%;height:100%" src="https://static-vusion.163yun.com/assets/cloud-ui/4.jpg"></van-image></van-swipe-item>
+  <van-swipe-item vusion-slot-name="default">
+    <van-image style="width:100%;height:100%" fit="cover" src="https://static-vusion.163yun.com/assets/cloud-ui/1.jpg"></van-image>
+  </van-swipe-item>
+  <van-swipe-item vusion-slot-name="default">
+    <van-image style="width:100%;height:100%" fit="cover" src="https://static-vusion.163yun.com/assets/cloud-ui/2.jpg"></van-image>
+  </van-swipe-item>
+  <van-swipe-item vusion-slot-name="default">
+    <van-image style="width:100%;height:100%" fit="cover" src="https://static-vusion.163yun.com/assets/cloud-ui/3.jpg"></van-image>
+  </van-swipe-item>
+  <van-swipe-item vusion-slot-name="default">
+    <van-image style="width:100%;height:100%" fit="cover" src="https://static-vusion.163yun.com/assets/cloud-ui/4.jpg"></van-image>
+  </van-swipe-item>
 
   <template #item="current">
     <van-swipe-item


### PR DESCRIPTION
关联：【vue】h5幻灯片组件，填充方式从‘填充’改为其他选项后再改回来，会发现和初始状态有差异 http://projectmanage.netease-official.lcap.163yun.com/dashboard/BugDetail?id=3000041470296064