### PR TITLE
fix(van-search): 修复搜索框清空图标显示判断

### DIFF
--- a/libraries/mobile-ui/src/fieldsonforsearch/index.js
+++ b/libraries/mobile-ui/src/fieldsonforsearch/index.js
@@ -120,7 +120,6 @@ export default createComponent({
       default: false,
     },
     drole: String,
-    frompara: String,
   },
 
   data() {
@@ -177,16 +176,12 @@ export default createComponent({
   methods: {
     showClear() {
       const readonly = this.getProp('readonly');
-      const frompara = this.getProp('frompara');
       if ((this.clearable && !readonly)) {
         const hasValue = isDef(this.currentValue) && this.currentValue !== '';
         const trigger =
           this.clearTrigger === 'always' ||
           (this.clearTrigger === 'focus' && this.focused);
 
-        if (frompara === 'vansearch') {
-          return trigger;
-        }
         return hasValue && trigger;
       }
     },

--- a/libraries/mobile-ui/src/search/index.tsx
+++ b/libraries/mobile-ui/src/search/index.tsx
@@ -146,7 +146,6 @@ function Search(
             'left-icon': slots['left-icon'],
             'right-icon': slots['right-icon'],
           }}
-          frompara="vansearch"
           {...fieldData}
         />
       </div>


### PR DESCRIPTION
关联： 【h5组件】搜索框组件 为空时清除图标也显示，预期有内容时才显示 http://projectmanage.netease-official.lcap.163yun.com/dashboard/BugDetail?id=2974296499914752