### PR TITLE
fix(van-datetime-picker): 修复滑动过快选择失效问题

### DIFF
--- a/libraries/mobile-ui/src/datetime-picker/shared.js
+++ b/libraries/mobile-ui/src/datetime-picker/shared.js
@@ -108,6 +108,8 @@ export const TimePickerMixin = {
       if (this.readonly || this.disabled) {
         //
       } else {
+        this.$refs.picker.confirm();
+
         let value = this.innerValue;
 
         // 低代码可用type： date、 time、 datetime、 year-month(即将废弃)


### PR DESCRIPTION
关联： h5时间选择组件，滑动过快，数据不更新 http://projectmanage.netease-official.lcap.163yun.com/dashboard/BugDetail?id=2854968094508288