### PR TITLE
fix(element-tree): 补全点击事件event类型

### DIFF
--- a/libraries/element-ui/src/pro-components/el-tree-pro/api.ts
+++ b/libraries/element-ui/src/pro-components/el-tree-pro/api.ts
@@ -414,7 +414,17 @@ namespace nasl.ui {
       title: '节点点击时',
       description: '节点点击时触发，泛型 `T` 表示树节点 ',
     })
-    onClick: (event: any) => any;
+    onClick: (event: {
+      node: {
+        actived: nasl.core.Boolean;
+        checked: nasl.core.Boolean;
+        data: T;
+        disabled: nasl.core.Boolean;
+        expanded: nasl.core.Boolean;
+        indeterminate: nasl.core.Boolean;
+        loading: nasl.core.Boolean;
+      }
+    }) => any;
 
     // @Event({
     //   title: 'On Drag End',

--- a/libraries/element-ui/src/pro-components/el-tree-pro/api.ts
+++ b/libraries/element-ui/src/pro-components/el-tree-pro/api.ts
@@ -423,6 +423,8 @@ namespace nasl.ui {
         expanded: nasl.core.Boolean;
         indeterminate: nasl.core.Boolean;
         loading: nasl.core.Boolean;
+        value: V;
+        label: nasl.core.String;
       }
     }) => any;
 


### PR DESCRIPTION
关联问题：【element默认权限模板】制品应用-权限中心-部门管理、部门名称点击后页面右侧相关信息会消失 http://projectmanage.netease-official.lcap.163yun.com/dashboard/BugDetail?id=3005553294062592   （见评论）