### PR TITLE
fix: 修复css-rule mixin获取class样式名兜底

### DIFF
--- a/libraries/mobile-ui/src/mixins/css-rule-classname.js
+++ b/libraries/mobile-ui/src/mixins/css-rule-classname.js
@@ -7,18 +7,9 @@ export default {
     };
   },
 
-  created() {
+  mounted() {
     const clx = cls(this.$vnode?.data?.class || [], this.$vnode?.data?.staticClass || '');
 
-    this.cssRuleClassName = clx.split(' ')?.find((className) => /^cw-css-rule-?/.test(className)) || '';
-  },
-
-  updated() {
-    if (this.cssRuleClassName) {
-      return;
-    }
-
-    const clx = cls(this.$vnode?.data?.class || [], this.$vnode?.data?.staticClass || '');
     this.cssRuleClassName = clx.split(' ')?.find((className) => /^cw-css-rule-?/.test(className)) || '';
   },
 };

--- a/libraries/mobile-ui/src/mixins/css-rule-classname.js
+++ b/libraries/mobile-ui/src/mixins/css-rule-classname.js
@@ -12,4 +12,13 @@ export default {
 
     this.cssRuleClassName = clx.split(' ')?.find((className) => /^cw-css-rule-?/.test(className)) || '';
   },
+
+  updated() {
+    if (this.cssRuleClassName) {
+      return;
+    }
+
+    const clx = cls(this.$vnode?.data?.class || [], this.$vnode?.data?.staticClass || '');
+    this.cssRuleClassName = clx.split(' ')?.find((className) => /^cw-css-rule-?/.test(className)) || '';
+  },
 };

--- a/libraries/pc-ui/src/mixins/css-rule-classname.js
+++ b/libraries/pc-ui/src/mixins/css-rule-classname.js
@@ -7,18 +7,9 @@ export default {
     };
   },
 
-  created() {
+  mounted() {
     const clx = cls(this.$vnode?.data?.class || [], this.$vnode?.data?.staticClass || '');
 
-    this.cssRuleClassName = clx.split(' ')?.find((className) => /^cw-css-rule-?/.test(className)) || '';
-  },
-
-  updated() {
-    if (this.cssRuleClassName) {
-      return;
-    }
-
-    const clx = cls(this.$vnode?.data?.class || [], this.$vnode?.data?.staticClass || '');
     this.cssRuleClassName = clx.split(' ')?.find((className) => /^cw-css-rule-?/.test(className)) || '';
   },
 };

--- a/libraries/pc-ui/src/mixins/css-rule-classname.js
+++ b/libraries/pc-ui/src/mixins/css-rule-classname.js
@@ -12,4 +12,13 @@ export default {
 
     this.cssRuleClassName = clx.split(' ')?.find((className) => /^cw-css-rule-?/.test(className)) || '';
   },
+
+  updated() {
+    if (this.cssRuleClassName) {
+      return;
+    }
+
+    const clx = cls(this.$vnode?.data?.class || [], this.$vnode?.data?.staticClass || '');
+    this.cssRuleClassName = clx.split(' ')?.find((className) => /^cw-css-rule-?/.test(className)) || '';
+  },
 };


### PR DESCRIPTION
IDE中有时created勾子拿不到