### PR TITLE
Fix: 样式上报解析css属性值报错问题修复

### DIFF
--- a/libraries/mobile-ui/ideusage.json
+++ b/libraries/mobile-ui/ideusage.json
@@ -811,7 +811,7 @@
                 "dismiss": "this.getDefaultElements().length > 0 && !this.getAttribute('dataSource')",
                 "display": 3,
                 "loopRule": "nth-child(n+2)",
-                "loopElem": "[class^='van-radio-group']:not([data-nodepath]",
+                "loopElem": "[class^='van-radio-group']:not([data-nodepath])",
                 "emptySlot": {
                     "display": "inline",
                     "condition": "!this.getAttribute('dataSource')",

--- a/libraries/mobile-ui/vite.config.js
+++ b/libraries/mobile-ui/vite.config.js
@@ -219,6 +219,11 @@ export default defineConfig(({ command }) => {
             VanSearch: {
               depCompList: ['VanField'],
             },
+            VanFieldtextarea: {
+              selectorPrefixMap: {
+                'van-fieldtextarea__newwrap': true,
+              },
+            },
           },
         },
       }),

--- a/libraries/pc-ui/src/theme/components/u-badge/index.vue
+++ b/libraries/pc-ui/src/theme/components/u-badge/index.vue
@@ -1,7 +1,7 @@
 <template>
 <div>
     <p style="display:inline-block;margin-right:20px;">
-        消息 <u-badge :value="3"></u-badge>
+        <u-badge :value="3">消息</u-badge>
     </p>
     <p style="display:inline-block;">
         <u-badge :value="3" dot corner>消息</u-badge>

--- a/packages/builder/package.json
+++ b/packages/builder/package.json
@@ -56,6 +56,7 @@
     "@types/babel__traverse": "^7.20.6",
     "@types/fs-extra": "^11.0.4",
     "@types/lodash": "^4.14.202",
+    "postcss-values-parser": "^6.0.2",
     "typescript": "^5.3.3",
     "vite": "^5.0.10"
   },

--- a/packages/builder/src/build/build-css-info.ts
+++ b/packages/builder/src/build/build-css-info.ts
@@ -5,6 +5,7 @@
 import fs from 'fs-extra';
 import path from 'path';
 import * as postcss from 'postcss';
+import { parse } from 'postcss-values-parser';
 import { camelCase, kebabCase, capitalize } from 'lodash';
 import type {
   LcapBuildOptions, CSSValue, CSSRule, SupportedCSSProperty,
@@ -12,6 +13,10 @@ import type {
 
 function sortMap(map: Record<string, any>) {
   return Object.fromEntries(Object.entries(map).sort(([a], [b]) => a.localeCompare(b)));
+}
+
+function getChildrenValue(val: Record<string, any>) {
+  return val.nodes.map((node) => node.toString());
 }
 
 function parseCSSInfo(cssContent: string, componentNameMap: Record<string, string | undefined>, cssRulesDesc: Record<string, Record<string, string>>, options: LcapBuildOptions) {
@@ -170,7 +175,10 @@ function parseCSSInfo(cssContent: string, componentNameMap: Record<string, strin
         if (decl.prop === 'background') {
           parsedStyle.backgroundColor = patchImportant({ defaultValue: decl.value });
         } else if (decl.prop === 'border') {
-          const arr = value.split(/\s+/);
+          if (value === undefined || value === null) return;
+          const parseVal = parse(value);
+          const arr = getChildrenValue(parseVal);
+          // const arr = value.split(/\s+/);
           if (arr.length < 3) return;
           const [borderWidth, borderStyle, borderColor] = arr;
           parsedStyle.borderLeftWidth = patchImportant({ defaultValue: borderWidth });
@@ -189,14 +197,20 @@ function parseCSSInfo(cssContent: string, componentNameMap: Record<string, strin
           (match = decl.prop.match(/^border-(left|right|top|bottom)$/))
         ) {
           const borderProp = match[1];
-          const arr = value.split(/\s+/);
+          if (value === undefined || value === null) return;
+          const parseVal = parse(value);
+          const arr = getChildrenValue(parseVal);
+          // const arr = value.split(/\s+/);
           if (arr.length < 3) return;
           const [borderWidth, borderStyle, borderColor] = arr;
           parsedStyle[`border${capitalize(borderProp)}Width`] = patchImportant({ defaultValue: borderWidth });
           parsedStyle[`border${capitalize(borderProp)}Style`] = patchImportant({ defaultValue: borderStyle });
           parsedStyle[`border${capitalize(borderProp)}Color`] = patchImportant({ defaultValue: borderColor });
         } else if (decl.prop === 'margin') {
-          const arr = value.split(/\s+/);
+          if (value === undefined || value === null) return;
+          const parseVal = parse(value);
+          const arr = getChildrenValue(parseVal);
+          // const arr = value.split(/\s+/);
           if (arr.length === 1) {
             parsedStyle.marginTop = patchImportant({ defaultValue: arr[0] });
             parsedStyle.marginRight = patchImportant({ defaultValue: arr[0] });
@@ -219,7 +233,10 @@ function parseCSSInfo(cssContent: string, componentNameMap: Record<string, strin
             parsedStyle.marginLeft = patchImportant({ defaultValue: arr[3] });
           }
         } else if (decl.prop === 'padding') {
-          const arr = value.split(/\s+/);
+          if (value === undefined || value === null) return;
+          const parseVal = parse(value);
+          const arr = getChildrenValue(parseVal);
+          // const arr = value.split(/\s+/);
           if (arr.length === 1) {
             parsedStyle.paddingTop = patchImportant({ defaultValue: arr[0] });
             parsedStyle.paddingRight = patchImportant({ defaultValue: arr[0] });
@@ -242,7 +259,10 @@ function parseCSSInfo(cssContent: string, componentNameMap: Record<string, strin
             parsedStyle.paddingLeft = patchImportant({ defaultValue: arr[3] });
           }
         } else if (decl.prop === 'border-radius') {
-          const arr = value.split(/\s+/);
+          if (value === undefined || value === null) return;
+          const parseVal = parse(value);
+          const arr = getChildrenValue(parseVal);
+          // const arr = value.split(/\s+/);
           if (arr.length === 1) {
             parsedStyle.borderTopLeftRadius = patchImportant({ defaultValue: arr[0] });
             parsedStyle.borderTopRightRadius = patchImportant({ defaultValue: arr[0] });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -907,6 +907,9 @@ importers:
       '@types/lodash':
         specifier: ^4.14.202
         version: 4.14.202
+      postcss-values-parser:
+        specifier: ^6.0.2
+        version: 6.0.2(postcss@8.4.35)
       typescript:
         specifier: ^5.3.3
         version: 5.3.3
@@ -7153,6 +7156,10 @@ packages:
     resolution: {integrity: sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==}
     engines: {node: '>=10'}
 
+  is-url-superb@4.0.0:
+    resolution: {integrity: sha512-GI+WjezhPPcbM+tqE9LnmsY5qqjwHzTvjJ36wxYX5ujNXefSUJ/T17r5bqDV8yLhcgB59KTPNOc9O9cmHTPWsA==}
+    engines: {node: '>=10'}
+
   is-utf8@0.2.1:
     resolution: {integrity: sha512-rMYPYvCzsXywIsldgLaSoPlw5PfoB/ssr7hY4pLfcodrA5M/eArza1a9VmTiNIBNMjOGr1Ow9mTyU2o69U6U9Q==}
 
@@ -8300,6 +8307,12 @@ packages:
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
+  postcss-values-parser@6.0.2:
+    resolution: {integrity: sha512-YLJpK0N1brcNJrs9WatuJFtHaV9q5aAOj+S4DI5S7jgHlRfm0PIbDCAFRYMQD5SHq7Fy6xsDhyutgS0QOAs0qw==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      postcss: ^8.2.9
+
   postcss@6.0.23:
     resolution: {integrity: sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==}
     engines: {node: '>=4.0.0'}
@@ -8473,6 +8486,9 @@ packages:
   quick-lru@4.0.1:
     resolution: {integrity: sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==}
     engines: {node: '>=8'}
+
+  quote-unquote@1.0.0:
+    resolution: {integrity: sha512-twwRO/ilhlG/FIgYeKGFqyHhoEhqgnKVkcmqMKi2r524gz3ZbDTcyFt38E9xjJI2vT+KbRNHVbnJ/e0I25Azwg==}
 
   raf@3.4.1:
     resolution: {integrity: sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==}
@@ -17639,6 +17655,8 @@ snapshots:
 
   is-unicode-supported@0.1.0: {}
 
+  is-url-superb@4.0.0: {}
+
   is-utf8@0.2.1: {}
 
   is-weakmap@2.0.1: {}
@@ -18925,6 +18943,13 @@ snapshots:
 
   postcss-value-parser@4.2.0: {}
 
+  postcss-values-parser@6.0.2(postcss@8.4.35):
+    dependencies:
+      color-name: 1.1.4
+      is-url-superb: 4.0.0
+      postcss: 8.4.35
+      quote-unquote: 1.0.0
+
   postcss@6.0.23:
     dependencies:
       chalk: 2.4.2
@@ -19139,6 +19164,8 @@ snapshots:
   queue-tick@1.0.1: {}
 
   quick-lru@4.0.1: {}
+
+  quote-unquote@1.0.0: {}
 
   raf@3.4.1:
     dependencies:


### PR DESCRIPTION
1、修复复合属性值的解析问题，如：border: 'calc(var(--border-width-base) * 2) solid var(--van-switch-on-background-color)'【bug3007825465317376】
2、修复bug3008281011410944、bug3008268680263680、bug3008251012593664