### PR TITLE
Fix/element UI zhh 0425

### DIFF
--- a/libraries/element-ui/design/_common/js/global-config/locale/zh_CN.ts
+++ b/libraries/element-ui/design/_common/js/global-config/locale/zh_CN.ts
@@ -7,7 +7,7 @@ export default {
     itemsPerPage: '{size} 条/页',
     jumpTo: '跳至',
     page: '页',
-    total: '共 {total} 条数据',
+    total: '共 {total} 条',
   },
   cascader: {
     empty: '暂无数据',

--- a/libraries/element-ui/design/_common/style/web/components/form/_index.less
+++ b/libraries/element-ui/design/_common/style/web/components/form/_index.less
@@ -57,15 +57,21 @@
     &--right {
       text-align: right;
     }
-
-    &--required {
-      label::before {
-        display: inline-block;
-        margin-right: @form-label-margin-right-required;
-        color: @form-color-error;
-        line-height: @form-label-line-height;
-        content: "*";
-      }
+    
+    &--required:not(&--required-right) label:before {
+      display: inline-block;
+      margin-right: @form-label-margin-right-required;
+      color: @form-color-error;
+      line-height: @form-label-line-height;
+      content: "*";
+    }
+  
+    &--required-right label:after {
+      display: inline-block;
+      margin-right: @form-label-margin-right-required;
+      color: @form-color-error;
+      line-height: @form-label-line-height;
+      content: "*";
     }
 
     &--colon {

--- a/libraries/element-ui/design/_common/style/web/components/textarea/_index.less
+++ b/libraries/element-ui/design/_common/style/web/components/textarea/_index.less
@@ -52,6 +52,9 @@
     display: flex;
     column-gap: @textarea-tips-gap;
     justify-content: space-between;
+    position: absolute;
+    bottom: 5px;
+    right: 10px;
   }
 
   &__info_wrapper_align {

--- a/libraries/element-ui/design/date-picker/DatePicker.tsx
+++ b/libraries/element-ui/design/date-picker/DatePicker.tsx
@@ -1,10 +1,8 @@
 import { defineComponent, watch, computed } from '@vue/composition-api';
 import dayjs from 'dayjs';
-import { CalendarIcon as ElCalendarIcon } from '@element-ui-icons';
 import isDate from 'lodash/isDate';
 
 import { usePrefixClass } from '../hooks/useConfig';
-import { useGlobalIcon } from '../hooks/useGlobalIcon';
 import useSingle from './hooks/useSingle';
 import {
   parseToDayjs, getDefaultFormat, formatTime, formatDate,
@@ -24,7 +22,6 @@ export default defineComponent({
   props,
   setup(props, { emit }) {
     const COMPONENT_NAME = usePrefixClass('date-picker');
-    const { CalendarIcon } = useGlobalIcon({ CalendarIcon: ElCalendarIcon });
 
     const {
       inputValue,
@@ -263,7 +260,6 @@ export default defineComponent({
       popupVisible,
       panelProps,
       isDisabled,
-      CalendarIcon,
     };
   },
   render() {
@@ -275,16 +271,7 @@ export default defineComponent({
       popupVisible,
       panelProps,
       isDisabled,
-      CalendarIcon,
     } = this;
-
-    const renderSuffixIcon = () => {
-      if (this.suffixIcon) return this.suffixIcon;
-      if (this.$scopedSlots.suffixIcon) return this.$scopedSlots.suffixIcon;
-      if (this.$scopedSlots['suffix-icon']) return this.$scopedSlots['suffix-icon'];
-
-      return () => <CalendarIcon />;
-    };
 
     return (
       <div class={COMPONENT_NAME}>
@@ -297,7 +284,7 @@ export default defineComponent({
           tips={this.tips}
           readonly={this.readonly}
           popupProps={datePickerPopupProps}
-          inputProps={{ suffixIcon: renderSuffixIcon(), ...datePickerInputProps }}
+          inputProps={{ ...datePickerInputProps }}
           popupVisible={popupVisible}
           clearable={this.clearable}
           allowInput={!this.readonly && this.allowInput}

--- a/libraries/element-ui/design/date-picker/DateRangePicker.tsx
+++ b/libraries/element-ui/design/date-picker/DateRangePicker.tsx
@@ -2,9 +2,7 @@ import {
   defineComponent, watch, computed, ref,
 } from '@vue/composition-api';
 import dayjs from 'dayjs';
-import { CalendarIcon as ElCalendarIcon } from '@element-ui-icons';
 import { usePrefixClass } from '../hooks/useConfig';
-import { useGlobalIcon } from '../hooks/useGlobalIcon';
 
 import props from './date-range-picker-props';
 import { DateValue, DateRangePickerPartial } from './type';
@@ -29,7 +27,6 @@ export default defineComponent({
   props,
   setup(props, { emit }) {
     const COMPONENT_NAME = usePrefixClass('date-range-picker');
-    const { CalendarIcon } = useGlobalIcon({ CalendarIcon: ElCalendarIcon });
     const { formDisabled } = useFormDisabled();
 
     const {
@@ -428,7 +425,6 @@ export default defineComponent({
       dateRangePickerRangeInputProps,
       popupVisible,
       panelProps,
-      CalendarIcon,
       isDisabled,
     };
   },
@@ -440,16 +436,7 @@ export default defineComponent({
       dateRangePickerRangeInputProps,
       popupVisible,
       panelProps,
-      CalendarIcon,
     } = this;
-
-    const renderSuffixIcon = () => {
-      if (this.suffixIcon) return this.suffixIcon;
-      if (this.$scopedSlots.suffixIcon) return this.$scopedSlots.suffixIcon;
-      if (this.$scopedSlots['suffix-icon']) return this.$scopedSlots['suffix-icon'];
-
-      return () => <CalendarIcon />;
-    };
 
     return (
       <div class={COMPONENT_NAME}>
@@ -462,7 +449,6 @@ export default defineComponent({
           readonly={this.readonly}
           popupProps={dateRangePickerPopupProps}
           rangeInputProps={{
-            suffixIcon: renderSuffixIcon(),
             ...dateRangePickerRangeInputProps,
           }}
           popupVisible={popupVisible}

--- a/libraries/element-ui/design/date-picker/hooks/useRange.ts
+++ b/libraries/element-ui/design/date-picker/hooks/useRange.ts
@@ -39,7 +39,7 @@ export default function useRange(props: ElDateRangePickerProps, { emit }: any) {
     borderless: props.borderless,
     size: props.size,
     clearable: props.clearable,
-    prefixIcon: props.prefixIcon,
+    // prefixIcon: props.prefixIcon,
     readonly: !props.allowInput || props.readonly,
     separator: props.separator || global.value.rangeSeparator,
     placeholder: props.placeholder || global.value.placeholder[props.mode],

--- a/libraries/element-ui/design/date-picker/hooks/useSingle.ts
+++ b/libraries/element-ui/design/date-picker/hooks/useSingle.ts
@@ -40,7 +40,7 @@ export default function useSingle(props: ElDatePickerProps, { emit }: any) {
     ref: inputRef,
     borderless: props.borderless,
     size: props.size,
-    prefixIcon: props.prefixIcon,
+    // prefixIcon: props.prefixIcon,
     placeholder: props.placeholder || global.value.placeholder[props.mode],
     class: [
       {

--- a/libraries/element-ui/design/form/form-item.tsx
+++ b/libraries/element-ui/design/form/form-item.tsx
@@ -119,6 +119,7 @@ export default mixins(getConfigReceiverMixins<FormItemConstructor, FormConfig>('
         `${this.componentName}__label`,
         {
           [`${this.componentName}__label--required`]: this.needRequiredMark,
+          [`${this.componentName}__label--required-right`]: this.needRequiredMark && this.requiredMarkPosition === 'right',
           [`${this.componentName}__label--colon`]: this.hasColon,
           [`${this.componentName}__label--top`]: this.getLabelContent() && (labelAlign === 'top' || !labelWidth),
           [`${this.componentName}__label--left`]: labelAlign === 'left' && labelWidth,
@@ -174,6 +175,9 @@ export default mixins(getConfigReceiverMixins<FormItemConstructor, FormConfig>('
       const requiredMark = this.$props.requiredMark ?? this.form.requiredMark ?? this.global.requiredMark;
       const isRequired = this.innerRules.filter((rule) => rule.required).length > 0;
       return requiredMark || (requiredMark ?? isRequired);
+    },
+    requiredMarkPosition(): ElFormProps['requiredMarkPosition'] {
+      return this.form.requiredMarkPosition;
     },
     innerRules(): FormRule[] {
       const parent = this.form;

--- a/libraries/element-ui/design/form/props.ts
+++ b/libraries/element-ui/design/form/props.ts
@@ -61,6 +61,11 @@ export default {
     type: Boolean,
     default: undefined,
   },
+  /** 必填符号（*）的位置，值为 left 表示在标签前面，值为 right 表示在标签后面 */
+  requiredMarkPosition: {
+    type: String as PropType<ElFormProps['requiredMarkPosition']>,
+    default: 'left' as ElFormProps['requiredMarkPosition'],
+  },
   /** 重置表单的方式，值为 empty 表示重置表单为空，值为 initial 表示重置表单数据为初始值 */
   resetType: {
     type: String as PropType<ElFormProps['resetType']>,

--- a/libraries/element-ui/design/form/type.ts
+++ b/libraries/element-ui/design/form/type.ts
@@ -56,6 +56,11 @@ export interface ElFormProps<FormData extends Data = Data> {
    */
   requiredMark?: boolean;
   /**
+   * 必填符号的位置，值为 `left` 或者 `right`，默认值为 `left`
+   * @default left
+   */
+  requiredMarkPosition?: 'left' | 'right';
+  /**
    * 重置表单的方式，值为 empty 表示重置表单为空，值为 initial 表示重置表单数据为初始值
    * @default empty
    */

--- a/libraries/element-ui/design/pagination/pagination.tsx
+++ b/libraries/element-ui/design/pagination/pagination.tsx
@@ -288,6 +288,7 @@ export default mixins(getConfigReceiverMixins<Vue, PaginationConfig>('pagination
   },
 
   render() {
+    if (this.hideOnSinglePage && this.pageCount === 1) return null as unknown as JSX.Element;
     const {
       PageFirstIcon,
       PageLastIcon,

--- a/libraries/element-ui/design/pagination/props.ts
+++ b/libraries/element-ui/design/pagination/props.ts
@@ -105,6 +105,11 @@ export default {
     type: [Boolean, Function] as PropType<ElPaginationProps['totalContent']>,
     default: true,
   },
+  /** 只有一页是是否隐藏 */
+  hideOnSinglePage: {
+    type: [Boolean, Function] as PropType<ElPaginationProps['hideOnSinglePage']>,
+    default: false,
+  },
   /** 当前页或分页大小发生变化时触发 */
   onChange: Function as PropType<ElPaginationProps['onChange']>,
   /** 当前页发生变化时触发 */

--- a/libraries/element-ui/design/pagination/type.ts
+++ b/libraries/element-ui/design/pagination/type.ts
@@ -102,6 +102,10 @@ export interface ElPaginationProps {
    */
   totalContent?: boolean | ElNode;
   /**
+   * 只有一页时是否隐藏
+   */
+  hideOnSinglePage?: boolean;
+  /**
    * 当前页或分页大小发生变化时触发
    */
   onChange?: (pageInfo: PageInfo) => void;

--- a/libraries/element-ui/design/select-input/props.ts
+++ b/libraries/element-ui/design/select-input/props.ts
@@ -91,6 +91,10 @@ export default {
   suffix: {
     type: [String, Function] as PropType<ElSelectInputProps['suffix']>,
   },
+  /** 组件前置图标 */
+  prefixIcon: {
+    type: Function as PropType<ElSelectInputProps['prefixIcon']>,
+  },
   /** 组件后置图标 */
   suffixIcon: {
     type: Function as PropType<ElSelectInputProps['suffixIcon']>,

--- a/libraries/element-ui/design/select-input/type.ts
+++ b/libraries/element-ui/design/select-input/type.ts
@@ -126,6 +126,10 @@ export interface ElSelectInputProps {
    */
   suffix?: string | ElNode;
   /**
+   * 组件前置图标
+   */
+  prefixIcon?: ElNode;
+  /**
    * 组件后置图标
    */
   suffixIcon?: ElNode;

--- a/libraries/element-ui/design/time-picker/time-picker.tsx
+++ b/libraries/element-ui/design/time-picker/time-picker.tsx
@@ -3,7 +3,6 @@ import {
 } from '@vue/composition-api';
 import dayjs from 'dayjs';
 import customParseFormat from 'dayjs/plugin/customParseFormat';
-import { TimeIcon as ElTimeIcon } from '@element-ui-icons';
 
 import TimePickerPanel from './panel/time-picker-panel';
 import ElSelectInput, { SelectInputFocusContext } from '../select-input';
@@ -12,7 +11,6 @@ import type { InputProps } from '../input';
 // hooks
 import useVModel from '../hooks/useVModel';
 import { useConfig, usePrefixClass } from '../hooks/useConfig';
-import { useGlobalIcon } from '../hooks/useGlobalIcon';
 import useFormDisabled from '../hooks/useFormDisabled';
 
 import props from './props';
@@ -26,7 +24,6 @@ export default defineComponent({
   setup(props, ctx) {
     const { classPrefix } = useConfig('classPrefix');
     const componentName = usePrefixClass('time-picker');
-    const { TimeIcon } = useGlobalIcon({ TimeIcon: ElTimeIcon });
     const { formDisabled } = useFormDisabled();
 
     const currentValue = ref('');
@@ -119,12 +116,10 @@ export default defineComponent({
       isShowPanel,
       global,
       currentValue,
-      TimeIcon,
       isDisabled,
     };
   },
   render() {
-    const { TimeIcon } = this;
     return (
       <div class={this.componentName}>
         <ElSelectInput
@@ -140,7 +135,6 @@ export default defineComponent({
               allowInput: !this.readonly && this.allowInput,
               readonly: this.readonly,
               class: this.inputClasses,
-              suffixIcon: () => <TimeIcon />,
               popupVisible: this.isShowPanel,
               placeholder: !this.innerValue ? this.placeholder || this.global.placeholder : undefined,
               value: this.isShowPanel ? this.currentValue : this.innerValue ?? undefined,

--- a/libraries/element-ui/src/components/el-dialog/index.less
+++ b/libraries/element-ui/src/components/el-dialog/index.less
@@ -7,4 +7,13 @@
   }
 }
 .el-dialog__wrapper {
+  .el-dialog__body {
+    padding-bottom: 64px;
+  }
+  .el-dialog__footer {
+    height: 64px;
+    width: 100%;
+    position: absolute;
+    bottom: 0;
+  }
 }

--- a/libraries/element-ui/src/components/el-dropdown/index.css
+++ b/libraries/element-ui/src/components/el-dropdown/index.css
@@ -1,0 +1,7 @@
+.el-dropdown .el-icon-arrow-down {
+  transition: transform 0.3s;
+}
+
+.el-dropdown.is-opened .el-icon-arrow-down {
+  transform: rotate(180deg);
+}

--- a/libraries/element-ui/src/components/el-dropdown/index.ts
+++ b/libraries/element-ui/src/components/el-dropdown/index.ts
@@ -1,3 +1,4 @@
+import './index.css';
 import Dropdown from 'element-ui/lib/dropdown';
 import DropdownMenu from 'element-ui/lib/dropdown-menu';
 import DropdownItem from 'element-ui/lib/dropdown-item';

--- a/libraries/element-ui/src/components/el-dropdown/plugins/basic-plugins.ts
+++ b/libraries/element-ui/src/components/el-dropdown/plugins/basic-plugins.ts
@@ -1,5 +1,6 @@
 /* 组件功能扩展插件 */
 import { at, isFunction, isNil } from 'lodash';
+import { ref, computed } from '@vue/composition-api';
 import { NaslComponentPluginOptions } from '@lcap/vue2-utils/plugins/index';
 import { ElDropdownMenu, ElDropdownItem } from '../index';
 import ElText from '../../el-text';
@@ -13,8 +14,23 @@ export const useExtendsPlugin: NaslComponentPluginOptions = {
       return size || 'small';
     });
 
+    const isOpened = ref(false);
+    function onVisibleChange(value: boolean) {
+      const visibleHandler = props.get('onVisibleChange');
+      if (typeof visibleHandler === 'function') {
+        visibleHandler(value);
+      }
+      isOpened.value = value;
+    }
+
+    const openClass = computed(() => {
+      return isOpened.value ? 'is-opened' : '';
+    });
+
     return {
       size: currentSize,
+      class: openClass,
+      onVisibleChange,
       slotDropdown: () => {
         const data = props.get<any[]>('data') || [];
         const [

--- a/libraries/element-ui/src/components/el-popconfirm/api.ts
+++ b/libraries/element-ui/src/components/el-popconfirm/api.ts
@@ -67,37 +67,41 @@ namespace nasl.ui {
     })
     cancelButtonText: nasl.core.String = '取消';
 
-    // @Prop({
-    //   group: '主要属性',
-    //   title: '确认按钮类型',
-    //   description: '确认按钮类型',
-    //   setter: { concept: 'InputSetter' },
-    // })
-    // confirmButtonType: nasl.core.String = 'Primary';
+    @Prop({
+      group: '主要属性',
+      title: '确认按钮类型',
+      description: '确认按钮类型',
+      setter: { concept: 'InputSetter' },
+    })
+    confirmButtonType: nasl.core.String = 'Primary';
 
-    // @Prop({
-    //   group: '主要属性',
-    //   title: '取消按钮类型',
-    //   description: '取消按钮类型',
-    //   setter: { concept: 'InputSetter' },
-    // })
-    // cancelButtonType: nasl.core.String = 'Text';
+    @Prop({
+      group: '主要属性',
+      title: '取消按钮类型',
+      description: '取消按钮类型',
+      setter: { concept: 'InputSetter' },
+    })
+    cancelButtonType: nasl.core.String = 'Text';
+    
+    @Prop({
+      title: '自定义图标',
+      description: '自定义图标',
+      group: '主要属性',
+      setter: {
+        concept: 'IconSetter',
+        customIconFont: 'LCAP_ELEMENTUI_ICONS',
+        hideUploadIcon: true,
+      },
+    })
+    icon: nasl.core.String = 'el-icon-question';
 
-    // @Prop({
-    //   group: '主要属性',
-    //   title: 'Icon',
-    //   description: 'Icon',
-    //   setter: { concept: 'InputSetter' },
-    // })
-    // icon: nasl.core.String = 'el-icon-question';
-
-    // @Prop({
-    //   group: '主要属性',
-    //   title: 'Icon 颜色',
-    //   description: 'Icon 颜色',
-    //   setter: { concept: 'InputSetter' },
-    // })
-    // iconColor: nasl.core.String = '#f90';
+    @Prop({
+      group: '主要属性',
+      title: 'Icon 颜色',
+      description: 'Icon 颜色',
+      setter: { concept: 'InputSetter' },
+    })
+    iconColor: nasl.core.String = '#f90';
 
     @Prop({
       group: '主要属性',

--- a/libraries/element-ui/src/components/el-row/api.ts
+++ b/libraries/element-ui/src/components/el-row/api.ts
@@ -87,6 +87,14 @@ namespace nasl.ui {
       tabKind: 'style',
     })
     gutter: nasl.core.Decimal | nasl.core.Integer = 0;
+    
+    @Prop({
+      group: '主要属性',
+      title: '自定义标签',
+      description: '自定义元素标签',
+      setter: { concept: 'InputSetter' },
+    })
+    tag: nasl.core.String = 'div';
 
     @Slot({
       title: '自定义默认内容',

--- a/libraries/element-ui/src/pro-components/el-date-picker-pro/api.ts
+++ b/libraries/element-ui/src/pro-components/el-date-picker-pro/api.ts
@@ -306,7 +306,7 @@ namespace nasl.ui {
         customIconFont: 'LCAP_ELEMENTUI_ICONS',
       },
     })
-    prefixIcon: nasl.core.String;
+    prefixIcon: nasl.core.String = 'el-icon-date';
 
     @Prop({
       title: '后缀图标',

--- a/libraries/element-ui/src/pro-components/el-date-picker-pro/plugins/basic-plugins.ts
+++ b/libraries/element-ui/src/pro-components/el-date-picker-pro/plugins/basic-plugins.ts
@@ -1,3 +1,4 @@
+import { CreateElement } from 'vue';
 import { NaslComponentPluginOptions, $render } from '@lcap/vue2-utils';
 import { DateRangeValue, DateRangePicker, DateValue } from '@element-pro';
 import {
@@ -7,8 +8,6 @@ import {
   useDisableDate,
   getChangeEventByValue,
   usePresets,
-  useInputProps,
-  useIcons,
 } from '../hooks';
 
 export { useFormFieldClass } from '../../../plugins/use-form-field-class';
@@ -21,7 +20,7 @@ export const useExtendsPlugin: NaslComponentPluginOptions = {
   props: [
     'range', 'autoWidth', 'align',
     'placeholderRight', 'startValue', 'endValue',
-    'maxTime', 'minTime', 'enablePresets',
+    'maxTime', 'minTime', 'enablePresets', 'prefixIcon', 'suffixIcon',
   ],
   setup(props) {
     const valueFormat = props.useComputed('converter', (v) => {
@@ -36,8 +35,33 @@ export const useExtendsPlugin: NaslComponentPluginOptions = {
     const events = useContextEvents(props, valueFormat);
     const disableDate = useDisableDate(props, DEFAULT_FORMAT);
     const presets = usePresets(props);
-    const inputProps = useInputProps(props);
-    const icons = useIcons(props);
+
+    const inputProps = props.useComputed<any>([
+      'autoWidth',
+      'align',
+      'prefixIcon',
+      'suffixIcon',
+    ], (
+      autoWidth = false,
+      align = 'left',
+      prefixIcon = 'el-icon-date',
+      suffixIcon,
+    ) => {
+      const inputStyleProps: any = {
+        autoWidth,
+        align,
+      };
+
+      if (prefixIcon) {
+        inputStyleProps.prefixIcon = (h: CreateElement) => h('el-icon', { attrs: { name: prefixIcon } });
+      }
+
+      if (suffixIcon) {
+        inputStyleProps.suffixIcon = (h: CreateElement) => h('el-icon', { attrs: { name: suffixIcon } });
+      }
+
+      return inputStyleProps;
+    });
 
     return {
       value,
@@ -45,7 +69,6 @@ export const useExtendsPlugin: NaslComponentPluginOptions = {
       inputProps,
       disableDate,
       presets,
-      ...icons,
       ...events,
       onChange: (v: DateValue | DateRangeValue, context) => {
         const [range] = props.get<[boolean]>(['range']);
@@ -68,7 +91,10 @@ export const useExtendsPlugin: NaslComponentPluginOptions = {
         if (!context.propsData.props.rangeInputProps) {
           context.propsData.props.rangeInputProps = {};
         }
-        context.propsData.props.rangeInputProps.inputProps = inputProps.value;
+        const { prefixIcon, suffixIcon, ...reset } = inputProps.value;
+        context.propsData.props.rangeInputProps.inputProps = reset;
+        context.propsData.props.rangeInputProps.prefixIcon = prefixIcon;
+        context.propsData.props.rangeInputProps.suffixIcon = suffixIcon;
 
         return h(DateRangePicker, context.propsData, context.childrenNodes);
       },

--- a/libraries/element-ui/src/pro-components/el-date-time-picker-pro/api.ts
+++ b/libraries/element-ui/src/pro-components/el-date-time-picker-pro/api.ts
@@ -284,7 +284,7 @@ namespace nasl.ui {
         customIconFont: 'LCAP_ELEMENTUI_ICONS',
       },
     })
-    prefixIcon: nasl.core.String;
+    prefixIcon: nasl.core.String = 'el-icon-date';
 
     @Prop({
       title: '后缀图标',

--- a/libraries/element-ui/src/pro-components/el-date-time-picker-pro/plugins/basic-plugins.ts
+++ b/libraries/element-ui/src/pro-components/el-date-time-picker-pro/plugins/basic-plugins.ts
@@ -1,3 +1,4 @@
+import { CreateElement } from 'vue';
 import { NaslComponentPluginOptions, $render } from '@lcap/vue2-utils';
 import {
   DateRangeValue,
@@ -17,8 +18,6 @@ import {
   useDisableDate,
   getChangeEventByValue,
   usePresets,
-  useInputProps,
-  useIcons,
 } from '../../el-date-picker-pro/hooks';
 
 export { useFormFieldClass } from '../../../plugins/use-form-field-class';
@@ -45,7 +44,7 @@ export const useExtendsPlugin: NaslComponentPluginOptions = {
   props: [
     'range', 'autoWidth', 'align',
     'placeholderRight', 'startValue', 'endValue',
-    'maxTime', 'minTime', 'enablePresets',
+    'maxTime', 'minTime', 'enablePresets', 'prefixIcon', 'suffixIcon',
   ],
   setup(props) {
     const { useComputed } = props;
@@ -65,8 +64,34 @@ export const useExtendsPlugin: NaslComponentPluginOptions = {
     const events = useContextEvents(props, valueFormat);
     const disableDate = useDisableDate(props, DEFAULT_FORMAT);
     const presets = usePresets(props);
-    const inputProps = useInputProps(props);
-    const icons = useIcons(props);
+
+    const inputProps = props.useComputed<any>([
+      'autoWidth',
+      'align',
+      'prefixIcon',
+      'suffixIcon',
+    ], (
+      autoWidth = false,
+      align = 'left',
+      prefixIcon = 'el-icon-date',
+      suffixIcon,
+    ) => {
+      const inputStyleProps: any = {
+        autoWidth,
+        align,
+      };
+
+      if (prefixIcon) {
+        inputStyleProps.prefixIcon = (h: CreateElement) => h('el-icon', { attrs: { name: prefixIcon } });
+      }
+
+      if (suffixIcon) {
+        inputStyleProps.suffixIcon = (h: CreateElement) => h('el-icon', { attrs: { name: suffixIcon } });
+      }
+
+      return inputStyleProps;
+    });
+
     const format = useComputed(['format', 'dateFormat', 'timeFormat'], (
       formatStr,
       dateFormat = 'YYYY-MM-DD',
@@ -107,7 +132,6 @@ export const useExtendsPlugin: NaslComponentPluginOptions = {
       disableDate,
       presets,
       format,
-      ...icons,
       ...events,
       valueType: DEFAULT_FORMAT,
       enableTimePicker: true,
@@ -147,7 +171,10 @@ export const useExtendsPlugin: NaslComponentPluginOptions = {
         if (!context.propsData.props.rangeInputProps) {
           context.propsData.props.rangeInputProps = {};
         }
-        context.propsData.props.rangeInputProps.inputProps = inputProps.value;
+        const { prefixIcon, suffixIcon, ...reset } = inputProps.value;
+        context.propsData.props.rangeInputProps.inputProps = reset;
+        context.propsData.props.rangeInputProps.prefixIcon = prefixIcon;
+        context.propsData.props.rangeInputProps.suffixIcon = suffixIcon;
 
         return h(DateRangePicker, context.propsData, context.childrenNodes);
       },

--- a/libraries/element-ui/src/pro-components/el-form-pro/api.ts
+++ b/libraries/element-ui/src/pro-components/el-form-pro/api.ts
@@ -253,6 +253,21 @@ namespace nasl.ui {
       setter: { concept: 'SwitchSetter' },
     })
     requiredMark: nasl.core.Boolean = false;
+    
+    @Prop({
+      group: '主要属性',
+      title: '必填标记显示位置',
+      description:
+        '表单必填符号（*）显示位置。可选项：left/right',
+      setter: {
+        concept: 'EnumSelectSetter',
+        options: [
+          { title: '左' },
+          { title: '右' },
+        ],
+      },
+    })
+    requiredMarkPosition: 'left' | 'right' = 'left';
 
     @Prop({
       group: '主要属性',

--- a/libraries/element-ui/src/pro-components/el-input-number-pro/api.ts
+++ b/libraries/element-ui/src/pro-components/el-input-number-pro/api.ts
@@ -224,7 +224,7 @@ namespace nasl.ui {
       description: '输入框下方提示文本，会根据不同的 `status` 呈现不同的样式。',
       setter: { concept: 'InputSetter' },
     })
-    private tips: nasl.core.String;
+    tips: nasl.core.String;
 
     @Prop({
       group: '主要属性',

--- a/libraries/element-ui/src/pro-components/el-input-pro/api.ts
+++ b/libraries/element-ui/src/pro-components/el-input-pro/api.ts
@@ -299,7 +299,7 @@ namespace nasl.ui {
       description: '输入框下方提示文本，会根据不同的 `status` 呈现不同的样式。',
       setter: { concept: 'InputSetter' },
     })
-    private tips: nasl.core.String;
+    tips: nasl.core.String;
 
     @Prop({
       group: '主要属性',

--- a/libraries/element-ui/src/pro-components/el-pagination-pro/api.ts
+++ b/libraries/element-ui/src/pro-components/el-pagination-pro/api.ts
@@ -219,6 +219,14 @@ namespace nasl.ui {
       setter: { concept: 'SwitchSetter' },
     })
     totalContent: nasl.core.Boolean = true;
+    
+    @Prop({
+      group: '交互属性',
+      title: '隐藏单页',
+      description: '只有一页时是否隐藏',
+      setter: { concept: 'SwitchSetter' },
+    })
+    hideOnSinglePage: nasl.core.Boolean = false;
 
     @Event({
       title: '改变时',

--- a/libraries/element-ui/src/pro-components/el-select-pro/api.ts
+++ b/libraries/element-ui/src/pro-components/el-select-pro/api.ts
@@ -71,13 +71,13 @@ namespace nasl.ui {
     })
     autoWidth: nasl.core.Boolean = false;
 
-    // @Prop({
-    //   group: '主要属性',
-    //   title: '自动聚焦',
-    //   description: '自动聚焦',
-    //   setter: { concept: 'SwitchSetter' },
-    // })
-    // autofocus: nasl.core.Boolean = false;
+    @Prop({
+      group: '主要属性',
+      title: '自动聚焦',
+      description: '自动聚焦',
+      setter: { concept: 'SwitchSetter' },
+    })
+    autofocus: nasl.core.Boolean = false;
 
     @Prop({
       group: '主要属性',
@@ -325,14 +325,14 @@ namespace nasl.ui {
     // })
     // popupProps: object;
 
-    // @Prop({
-    //   group: '主要属性',
-    //   sync: true,
-    //   title: 'Popup Visible',
-    //   description: '是否显示下拉框。支持语法糖 `.sync`',
-    //   setter: { concept: 'SwitchSetter' },
-    // })
-    // popupVisible: nasl.core.Boolean;
+    @Prop({
+      group: '主要属性',
+      sync: true,
+      title: '是否显示下拉框',
+      description: '是否显示下拉框。支持语法糖 `.sync`',
+      setter: { concept: 'SwitchSetter' },
+    })
+    popupVisible: nasl.core.Boolean;
 
     // @Prop({
     //   group: '主要属性',
@@ -686,6 +686,29 @@ namespace nasl.ui {
       setter: { concept: 'SwitchSetter' },
     })
     disabled: nasl.core.Boolean = false;
+    
+    @Prop({
+      group: '状态属性',
+      title: '为空自动禁用',
+      description: '为空时置灰显示，且禁止任何交互（焦点、点击、选择、输入等）',
+      docDescription: '置灰显示，且禁止任何交互（焦点、点击、选择、输入等）',
+      setter: {
+          concept: 'SwitchSetter',
+      },
+    })
+    emptyDisabled: nasl.core.Boolean = false;
+    
+    @Prop({
+      group: '主要属性',
+      title: '弹出层位置依据',
+      description: '设置弹出层依据哪个元素定位位置，可选值：`body`表示添加到 document.body，`reference`表示添加到参考元素中。',
+      docDescription: '设置添加到哪个元素',
+      setter: {
+          concept: 'EnumSelectSetter',
+          options: [{ title: '全局body' }, { title: '引用元素下' }],
+      },
+    })
+    appendTo: 'body' | 'reference' = 'body';
 
     // @Prop({
     //   group: '主要属性',

--- a/libraries/element-ui/src/pro-components/el-select-pro/plugins/basic-plugins.ts
+++ b/libraries/element-ui/src/pro-components/el-select-pro/plugins/basic-plugins.ts
@@ -7,7 +7,7 @@ import _, {
 import { type VNode } from 'vue';
 import { computed, unref } from '@vue/composition-api';
 import { createUseUpdateSync, NaslComponentPluginOptions } from '@lcap/vue2-utils';
-import { Tag, SelectValue, SelectValueChangeTrigger } from '@element-pro';
+import { Tag, SelectValue, SelectValueChangeTrigger, PopupProps } from '@element-pro';
 import { isEmptyVNodes } from '@lcap/vue2-utils/plugins/utils';
 
 export { useDataSource, useInitialLoaded } from '@lcap/vue2-utils';
@@ -57,8 +57,16 @@ export const useSelect: NaslComponentPluginOptions = {
 
     const keys = props.useComputed('keys', (v) => (_.isObject(v) ? v : {}));
 
+    const disabled = computed(() => {
+      const isPropDisabled = props.useComputed('disabled', (v) => v || false).value;
+      const isEmptyDisabled = props.useComputed('emptyDisabled', (v) => v || false).value;
+      const hasOptions = options.value && options.value.length > 0;
+      return isPropDisabled || (isEmptyDisabled && !hasOptions);
+    });
+
     return {
       options,
+      disabled,
       slotValueDisplay: ({ value, onClose }) => {
         const slotValue = props.get<(c: any) => VNode[]>('slotValue');
         const [
@@ -122,6 +130,21 @@ export const useSelect: NaslComponentPluginOptions = {
           label: textField.value,
           ...keys.value,
         };
+      }),
+    };
+  },
+};
+
+export const usePopupProps = {
+  setup(props) {
+    const appendTo = props.useComputed('appendTo', (v) => v || 'body').value;
+
+    return {
+      popupProps: props.useComputed('popupProps', (popupProps = {}) => {
+        return {
+          attach: appendTo === 'reference' ? (node) => node : 'body',
+          ...popupProps,
+        } as PopupProps;
       }),
     };
   },

--- a/libraries/element-ui/src/pro-components/el-textarea-pro/api.ts
+++ b/libraries/element-ui/src/pro-components/el-textarea-pro/api.ts
@@ -172,7 +172,7 @@ namespace nasl.ui {
       description: '输入框下方提示文本，会根据不同的 `status` 呈现不同的样式。',
       setter: { concept: 'InputSetter' },
     })
-    private tips: nasl.core.String;
+    tips: nasl.core.String;
 
     @Prop({
       group: '主要属性',

--- a/libraries/element-ui/src/pro-components/el-time-picker-pro/api.ts
+++ b/libraries/element-ui/src/pro-components/el-time-picker-pro/api.ts
@@ -209,7 +209,7 @@ namespace nasl.ui {
         customIconFont: 'LCAP_ELEMENTUI_ICONS',
       },
     })
-    prefixIcon: nasl.core.String;
+    prefixIcon: nasl.core.String = 'el-icon-time';
 
     @Prop({
       title: '后缀图标',

--- a/libraries/element-ui/src/pro-components/el-time-picker-pro/plugins/basic-plugins.ts
+++ b/libraries/element-ui/src/pro-components/el-time-picker-pro/plugins/basic-plugins.ts
@@ -103,7 +103,7 @@ export const useExtensPlugin: NaslComponentPluginOptions = {
     ], (
       autoWidth = false,
       align = 'left',
-      prefixIcon,
+      prefixIcon = 'el-icon-time',
       suffixIcon,
     ) => {
       const inputStyleProps: any = {


### PR DESCRIPTION
1. 表单：增加必填标记位置属性
2. 对话框：footer默认绝对定位，调整高度后位置不变
3. 单行输入：增加普通文本提示+文本框颜色属性
4. 下拉菜单：增加下拉时翻转箭头
5. 选择器：增加自动获取焦点、弹出层位置依据、展示暂无数据文案、为空自动禁用、弹出状态
6. 栅格布局：增加自定义元素tag属性
7. 多行输入：最大数在输入框右下角内部显示
8. 时间选择器：修复图标位置+可设置prefixIcon和suffixIcon
9. 翻页器：支持hide-on-single-page，修改total提示语
10. 气泡确认框：增加确认按钮类型属性、取消按钮类型属性、缺少自定义icon及icon颜色属性