### PR TITLE
fix(UTableView): 开启多选和树形模式，双向绑定的数据清理为空数组时仍然选中

### DIFF
--- a/libraries/pc-ui/src/components/u-table-view.vue/index.vue
+++ b/libraries/pc-ui/src/components/u-table-view.vue/index.vue
@@ -1718,6 +1718,7 @@ export default {
                 this.currentValues = values;
             }
             // 暂存选中行
+            this.checkedItems = {};
             if (this.currentData) {
                 this.currentData.forEach((item) => {
                     if (item.checked) {


### PR DESCRIPTION
cherry-pick into test