### PR TITLE
fix(UUploader): checkFile适配IDE入参改为fileInfo，类型改为nasl.io.FileInfo (#1300)

### DIFF
--- a/libraries/pc-ui/src/components/u-uploader.vue/api.ts
+++ b/libraries/pc-ui/src/components/u-uploader.vue/api.ts
@@ -422,7 +422,7 @@ namespace nasl.ui {
             },
             bindOpen: true,
         })
-        checkFile: (file: nasl.io.File) => nasl.core.String;
+        checkFile: (fileInfo: nasl.io.FileInfo) => nasl.core.String;
 
         @Prop({
             group: '主要属性',


### PR DESCRIPTION
cherry-pick into release/v4.3.0