### PR TITLE
fix(el-tree-select-pro): 修复因缺少 props 依赖导致数据更新异常的问题

### DIFF
--- a/libraries/element-ui/src/pro-components/el-tree-select-pro/plugins/basic-plugins.ts
+++ b/libraries/element-ui/src/pro-components/el-tree-select-pro/plugins/basic-plugins.ts
@@ -12,7 +12,7 @@ export { usePopupTheme } from '../../../plugins/use-popup-theme';
 export const useUpdateSync = createUseUpdateSync();
 
 export const useTreeSelect: NaslComponentPluginOptions = {
-  props: ['valueField', 'labelField', 'parentField', 'data', 'optionIsSlot'],
+  props: ['valueField', 'labelField', 'parentField', 'data', 'optionIsSlot', 'childrenField'],
   setup(props, ctx) {
     const valueField = props.useComputed('valueField', (v) => v || 'value');
     const textField = props.useComputed('textField', (v) => v || 'label');


### PR DESCRIPTION
el-tree-select-pro 组件的 `useTreeSelect` 插件中，`useComputed` 钩子依赖了 `childrenField` 属性来构建树形结构。

由于 `props` 声明中遗漏了 `childrenField`，导致 `useComputed` 无法正确追踪其变化，在某些场景下引发异常刷新的问题。

本次修复将 `childrenField` 添加到 `props` 依赖数组中，确保组件能够正确响应 `childrenField` 属性的变更，保证树形数据的稳定更新。