### PR TITLE
fix(ideusage): utableview 表格分组在IDE里拖拽换位置没有刷新

### DIFF
--- a/libraries/pc-ui/ideusage.json
+++ b/libraries/pc-ui/ideusage.json
@@ -632,7 +632,7 @@
        "ideusage": {
         "idetype": "container",
         "structured": true,
-        "forceRefresh": "transparent",
+        "forceRefresh": "parent",
         "childAccept": "['u-table-view-column', 'u-table-view-column-dynamic'].includes(target.tag)",
         "parentAccept": "['u-table-view', 'u-table-view-column-group'].includes(target.tag)",
         "selector": [


### PR DESCRIPTION
cherry-pick into release/v4.2.0