### PR TITLE
fix(u-tree-select-new): 修复函数数据源懒加载时选中项文本回显失败

### DIFF
--- a/libraries/pc-ui/src/components/u-tree-select-new.vue/demos/examples/ExamplesDemo13.vue
+++ b/libraries/pc-ui/src/components/u-tree-select-new.vue/demos/examples/ExamplesDemo13.vue
@@ -1,0 +1,162 @@
+<!-- 函数数据源懒加载回显调试 -->
+<template>
+  <div :style="{ display: 'flex', flexDirection: 'column', gap: '24px', maxWidth: '640px' }">
+    <section>
+      <h4 :style="{ margin: '0 0 8px' }">场景 1：初始值回显（子节点 value=1.1）</h4>
+      <p :style="{ margin: '0 0 8px', color: '#666', fontSize: '12px' }">
+        initialLoad=false，仅通过 loadUntilSelectedItem 逐级加载，验证选中项文本能否回显。
+      </p>
+      <u-tree-select-new
+        ref="echoSelect"
+        v-model="echoValue"
+        :data-source="load"
+        text-field="text"
+        value-field="value"
+        placeholder="请选择"
+        clearable
+        :style="{ width: '320px' }"
+        @select="onEchoSelect"
+        @load="onEchoLoad"
+      />
+      <debug-panel title="场景 1 调试信息" :info="echoDebugInfo" />
+    </section>
+
+    <section>
+      <h4 :style="{ margin: '0 0 8px' }">场景 2：展开后手动选择</h4>
+      <p :style="{ margin: '0 0 8px', color: '#666', fontSize: '12px' }">
+        initialLoad=false，需先点击展开加载子级，再选择节点，验证选中后文本回显。
+      </p>
+      <u-tree-select-new
+        ref="manualSelect"
+        v-model="manualValue"
+        :data-source="load"
+        :initial-load="false"
+        text-field="text"
+        value-field="value"
+        placeholder="请展开后选择"
+        clearable
+        :style="{ width: '320px' }"
+        @select="onManualSelect"
+        @load="onManualLoad"
+      />
+      <debug-panel title="场景 2 调试信息" :info="manualDebugInfo" />
+    </section>
+
+    <section :style="{ fontSize: '12px', color: '#999' }">
+      <div>mock 数据结构：</div>
+      <div>根节点 → 节点 1 (value=1) → 节点 1.1 (value=1.1) / 节点 1.2 (value=1.2)</div>
+    </section>
+  </div>
+</template>
+
+<script>
+const mockRequest = (data, timeout = 300) => new Promise((resolve) => setTimeout(() => resolve(data), timeout));
+
+const DebugPanel = {
+  name: 'debug-panel',
+  props: {
+    title: String,
+    info: Object,
+  },
+  template: `
+    <pre :style="{
+      margin: '8px 0 0',
+      padding: '12px',
+      background: '#f7f8fa',
+      border: '1px solid #ebedf0',
+      borderRadius: '4px',
+      fontSize: '12px',
+      lineHeight: '1.6',
+      whiteSpace: 'pre-wrap',
+      wordBreak: 'break-all',
+    }">{{ title }}
+{{ formattedInfo }}</pre>
+  `,
+  computed: {
+    formattedInfo() {
+      return Object.entries(this.info || {})
+        .map(([key, value]) => `${key}: ${value}`)
+        .join('\n');
+    },
+  },
+};
+
+export default {
+  components: {
+    DebugPanel,
+  },
+  data() {
+    return {
+      echoValue: '1.1',
+      manualValue: null,
+      echoLoadCount: 0,
+      manualLoadCount: 0,
+      echoSelectEvent: '-',
+      manualSelectEvent: '-',
+    };
+  },
+  computed: {
+    echoDebugInfo() {
+      const vm = this.$refs.echoSelect;
+      return this.buildDebugInfo(vm, {
+        value: this.echoValue,
+        loadCount: this.echoLoadCount,
+        lastSelectEvent: this.echoSelectEvent,
+      });
+    },
+    manualDebugInfo() {
+      const vm = this.$refs.manualSelect;
+      return this.buildDebugInfo(vm, {
+        value: this.manualValue,
+        loadCount: this.manualLoadCount,
+        lastSelectEvent: this.manualSelectEvent,
+      });
+    },
+  },
+  methods: {
+    load(params) {
+      console.log('load', params);
+      if (!params.node) {
+        return mockRequest([
+          { text: '节点 1', value: '1' },
+          { text: '节点 2', value: '2', isLeaf: true },
+        ]);
+      }
+      if (params.node.value === '1') {
+        return mockRequest([
+          { text: '节点 1.1', value: '1.1', isLeaf: true },
+          { text: '节点 1.2', value: '1.2', isLeaf: true },
+        ]);
+      }
+      return mockRequest([]);
+    },
+    buildDebugInfo(vm, extra) {
+      const selectedItem = vm && vm.selectedItem;
+      return {
+        ...extra,
+        selectedItemText: selectedItem ? selectedItem.text : '(空)',
+        selectedItemFound: selectedItem ? '是' : '否',
+        dataSourceObjSize: vm && vm.dataSourceObj ? Object.keys(vm.dataSourceObj).length : 0,
+      };
+    },
+    onEchoSelect(event) {
+      this.echoSelectEvent = JSON.stringify({
+        value: event && event.value,
+        nodeText: event && event.node && event.node.text,
+      });
+    },
+    onManualSelect(event) {
+      this.manualSelectEvent = JSON.stringify({
+        value: event && event.value,
+        nodeText: event && event.node && event.node.text,
+      });
+    },
+    onEchoLoad() {
+      this.echoLoadCount += 1;
+    },
+    onManualLoad() {
+      this.manualLoadCount += 1;
+    },
+  },
+};
+</script>

--- a/libraries/pc-ui/src/components/u-tree-select-new.vue/index.vue
+++ b/libraries/pc-ui/src/components/u-tree-select-new.vue/index.vue
@@ -343,6 +343,14 @@ export default {
             this.loadUntilSelectedItem();
             return this.dataSourceObj;
         },
+        mergeDataSourceObj(list, type) {
+            if (Array.isArray(list) && list.length) {
+                this.trans2Obj(this.dataSourceNodeList, list, undefined, type);
+                this.dataSourceObj = { ...this.dataSourceNodeList, ...this.virtualNodeList };
+            }
+            this.loadUntilSelectedItem();
+            return this.dataSourceNodeList;
+        },
         // 从虚拟节点中收集数据
         collectFromVNodes() {
             // dirty hack：每次插槽变化时，vue都会将实例上的$slots对象重新赋值
@@ -463,6 +471,7 @@ export default {
             this.actualValue = $event;
             this.$emit('update:value', $event, this);
             this.$emit('input', $event, this);
+            this.syncDataSourceFromTreeView();
             this.$nextTick(() => {
                 if ($event !== null && $event !== undefined && !this.checkable) {
                     this.close();
@@ -486,8 +495,10 @@ export default {
                 if (Array.isArray(data) && data.length) {
                     const item = this.loadChildren(data);
                     if (item) {
+                        const childrenField = item.childrenField || this.childrenField;
                         this.load({
                             node: item,
+                            childrenField,
                         });
                     }
                 } else {
@@ -499,12 +510,13 @@ export default {
             let item;
             if (Array.isArray(list) && list.length) {
                 for (let i = 0; i < list.length; i++) {
-                    const { childrenField, isLoaded } = list[i];
-                    const children = this.$at(list[i], childrenField);
+                    const node = list[i];
+                    const childrenField = node.childrenField || this.childrenField;
+                    const children = this.$at(node, childrenField);
                     if (Array.isArray(children) && children.length) {
                         item = this.loadChildren(children);
-                    } else if (childrenField && !isLoaded) {
-                        item = list[i];
+                    } else if (!node.isLoaded && !this.$at(node, this.isLeafField)) {
+                        item = node;
                     }
                     if (item) {
                         break;
@@ -521,9 +533,9 @@ export default {
             const createLoad = (rawLoad) => async (params = {}) => {
                 const result = await rawLoad(params);
                 if (result) {
-                    const { node } = params || {};
+                    const { node, childrenField: paramsChildrenField } = params || {};
                     if (node) {
-                        const { childrenField } = node;
+                        const childrenField = paramsChildrenField || node.childrenField || this.childrenField;
                         this.$setAt(node, childrenField, result);
                         node.isLoaded = true;
                     } else {
@@ -567,6 +579,9 @@ export default {
             this.popperOpened = true; // 刚打开时，除非是没有加载，否则保留上次的 filter 过的数据
             this.$emit('open', $event, this);
             this.$emit('update:opened', true);
+            this.$nextTick(() => {
+                this.seedTreeViewDataFromSelect();
+            });
             if (this.filterable) {
                 this.filtering = true;
                 setTimeout(() => {
@@ -635,7 +650,26 @@ export default {
             this.$emit('before-load');
         },
         onLoad() {
+            this.syncDataSourceFromTreeView();
             this.$emit('load', undefined, this);
+        },
+        syncDataSourceFromTreeView() {
+            const treeView = this.$refs.treeView;
+            if (!treeView || !treeView.currentDataSource || !Array.isArray(treeView.currentDataSource.data)) {
+                return;
+            }
+            this.currentDataSource.data = treeView.currentDataSource.data;
+            this.mergeDataSourceObj(this.currentDataSource.data, 'dataSource');
+        },
+        seedTreeViewDataFromSelect() {
+            const treeView = this.$refs.treeView;
+            const selectData = this.currentDataSource && this.currentDataSource.data;
+            if (!treeView || !treeView.currentDataSource || !Array.isArray(selectData) || !selectData.length) {
+                return;
+            }
+            if (!Array.isArray(treeView.currentDataSource.data) || !treeView.currentDataSource.data.length) {
+                treeView.currentDataSource.data = selectData;
+            }
         },
         clear() {
             const oldValue = this.actualValue;

--- a/libraries/pc-ui/src/components/u-tree-select-new.vue/stories/examples.stories.js
+++ b/libraries/pc-ui/src/components/u-tree-select-new.vue/stories/examples.stories.js
@@ -13,6 +13,7 @@ import ExamplesDemo9 from '../demos/examples/ExamplesDemo9.vue';
 import ExamplesDemo10 from '../demos/examples/ExamplesDemo10.vue';
 import ExamplesDemo11 from '../demos/examples/ExamplesDemo11.vue';
 import ExamplesDemo12 from '../demos/examples/ExamplesDemo12.vue';
+import ExamplesDemo13 from '../demos/examples/ExamplesDemo13.vue';
 
 Vue.use(CloudUI);
 
@@ -133,6 +134,15 @@ export const 筛选方式 = {
   render: () => ({
     components: {
       DeprecatedDemo: ExamplesDemo12,
+    },
+    template: '<deprecated-demo />',
+  }),
+};
+
+export const 函数数据源懒加载回显调试 = {
+  render: () => ({
+    components: {
+      DeprecatedDemo: ExamplesDemo13,
     },
     template: '<deprecated-demo />',
   }),

--- a/libraries/pc-ui/src/components/u-tree-select-new.vue/tests/lazy-load.test.js
+++ b/libraries/pc-ui/src/components/u-tree-select-new.vue/tests/lazy-load.test.js
@@ -1,0 +1,103 @@
+import { test, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { UTreeSelectNew } from '../index';
+
+const sleep = (ms) => new Promise((resolve) => {
+  setTimeout(() => resolve(true), ms);
+});
+
+async function load(params) {
+  if (!params.node) {
+    return [{ text: '节点 1', value: '1' }];
+  }
+  if (params.node.value === '1') {
+    return [
+      { text: '节点 1.1', value: '1.1' },
+      { text: '节点 1.2', value: '1.2' },
+    ];
+  }
+  return [];
+}
+
+test('函数数据源懒加载时回显选中项文本', async () => {
+  const wrapper = mount(UTreeSelectNew, {
+    propsData: {
+      value: '1.1',
+      initialLoad: false,
+      dataSource: load,
+    },
+  });
+
+  await sleep(50);
+  await wrapper.vm.$nextTick();
+
+  expect(wrapper.vm.selectedItem).toBeTruthy();
+  expect(wrapper.vm.selectedItem.text).toBe('节点 1.1');
+  expect(wrapper.text()).toContain('节点 1.1');
+});
+
+test('展开懒加载后选中项能正确回显文本', async () => {
+  const wrapper = mount(UTreeSelectNew, {
+    propsData: {
+      value: null,
+      opened: true,
+      initialLoad: false,
+      dataSource: load,
+    },
+  });
+
+  await wrapper.vm.$nextTick();
+  const treeView = wrapper.vm.$refs.treeView;
+  expect(treeView).toBeTruthy();
+
+  await treeView.load();
+  await sleep(50);
+  await wrapper.vm.$nextTick();
+
+  const rootNode = treeView.nodeVMs[0];
+  await rootNode.load();
+  await sleep(50);
+  await wrapper.vm.$nextTick();
+
+  wrapper.vm.onUpdateValue('1.1');
+  await wrapper.vm.$nextTick();
+
+  expect(wrapper.vm.selectedItem).toBeTruthy();
+  expect(wrapper.vm.selectedItem.text).toBe('节点 1.1');
+  expect(wrapper.text()).toContain('节点 1.1');
+});
+
+test('已有回显值展开子节点后不应清空文本', async () => {
+  const wrapper = mount(UTreeSelectNew, {
+    propsData: {
+      value: '1.1',
+      opened: true,
+      initialLoad: false,
+      dataSource: load,
+    },
+  });
+
+  await sleep(50);
+  await wrapper.vm.$nextTick();
+
+  expect(wrapper.vm.selectedItem).toBeTruthy();
+  expect(wrapper.text()).toContain('节点 1.1');
+
+  const treeView = wrapper.vm.$refs.treeView;
+  await treeView.load();
+  await sleep(50);
+  await wrapper.vm.$nextTick();
+
+  expect(wrapper.vm.actualValue).toBe('1.1');
+  expect(wrapper.vm.selectedItem).toBeTruthy();
+  expect(wrapper.text()).toContain('节点 1.1');
+
+  const rootNode = treeView.nodeVMs[0];
+  await rootNode.toggle(true);
+  await sleep(50);
+  await wrapper.vm.$nextTick();
+
+  expect(wrapper.vm.actualValue).toBe('1.1');
+  expect(wrapper.vm.selectedItem).toBeTruthy();
+  expect(wrapper.text()).toContain('节点 1.1');
+});


### PR DESCRIPTION
修正 childrenField 取值与 tree-view 数据同步逻辑，合并而非覆盖 dataSourceObj，避免展开后回显文本被清空，并补充调试 demo 与测试用例。